### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for interacting with Astra DB. MCP extends the capabilities of Large Language Models (LLMs) by allowing them to interact with external systems as agents.
 
+<a href="https://glama.ai/mcp/servers/tigix0yf4b">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/tigix0yf4b/badge" alt="Astra DB Server MCP server" />
+</a>
+
 ## Prerequisites
 
 You need to have a running Astra DB database. If you don't have one, you can create a free database [here](https://astra.datastax.com/register). From there, you can get two things you need:


### PR DESCRIPTION
This PR adds a badge for the [Astra DB MCP Server](https://glama.ai/mcp/servers/tigix0yf4b) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/tigix0yf4b">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/tigix0yf4b/badge" alt="Astra DB Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.