### PR TITLE
Adds glama.json file to allow us to claim the server on Glama

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "TejasQ",
+    "philnash"
+  ]
+}

--- a/glama.json
+++ b/glama.json
@@ -2,6 +2,7 @@
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "maintainers": [
     "TejasQ",
-    "philnash"
+    "philnash",
+    "msmygit"
   ]
 }


### PR DESCRIPTION
Glama makes instructions available for claiming servers. When a server is owned by an organisation, you need a `glama.json` file to prove the maintainers. This adds one so that we can claim it and 

* Choose which category your server belongs to
* Update your server's description & configuration
* Receive notifications of reviews

See instructions:

<img width="506" alt=" " src="https://github.com/user-attachments/assets/37204c9c-8276-480d-9370-6767812fd8e9" />