### PR TITLE
feat - tests + evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ The server provides the following tools for interacting with Astra DB:
 All notable changes to this project will be documented in [this file](./CHANGELOG.md).
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+
+## Running evals
+
+The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
+
+```bash
+OPENAI_API_KEY=your-key  npx mcp-eval evals.ts tools.ts
+```
 ## ❤️ Contributors
 
 [![astra-db-mcp contributors](https://contrib.rocks/image?repo=datastax/astra-db-mcp)](https://github.com/datastax/astra-db-mcp/graphs/contributors)

--- a/evals.ts
+++ b/evals.ts
@@ -1,0 +1,59 @@
+//evals.ts
+
+import { EvalConfig } from 'mcp-evals';
+import { openai } from "@ai-sdk/openai";
+import { grade, EvalFunction } from "mcp-evals";
+
+const GetCollectionsEval: EvalFunction = {
+    name: "GetCollections Tool Evaluation",
+    description: "Evaluates retrieving all collections from the Astra DB database",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "What collections exist in my Astra DB database?");
+        return JSON.parse(result);
+    }
+};
+
+const CreateCollectionEval: EvalFunction = {
+  name: "CreateCollection Tool Evaluation",
+  description: "Evaluates the creation of a new collection in the database",
+  run: async () => {
+    const result = await grade(openai("gpt-4"), "Please create a new vector collection named 'my_test_collection' with dimension 1024 in the database.");
+    return JSON.parse(result);
+  }
+};
+
+const UpdateCollectionEval: EvalFunction = {
+    name: "UpdateCollection Tool Evaluation",
+    description: "Evaluates the ability to update an existing collection in the database",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please rename the collection named 'myOldCollection' to 'myNewCollection'.");
+        return JSON.parse(result);
+    }
+};
+
+const DeleteCollectionEval: EvalFunction = {
+    name: "DeleteCollection Tool Evaluation",
+    description: "Evaluates the tool's ability to delete a specified collection from the database",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please delete the 'TestCollection' collection from the database.");
+        return JSON.parse(result);
+    }
+};
+
+const ListRecordsEval: EvalFunction = {
+    name: "ListRecords Tool Evaluation",
+    description: "Evaluates the listing of records from a collection in the database",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please list up to 5 records from the 'users' collection using the 'ListRecords' tool.");
+        return JSON.parse(result);
+    }
+};
+
+const config: EvalConfig = {
+    model: openai("gpt-4"),
+    evals: [GetCollectionsEval, CreateCollectionEval, UpdateCollectionEval, DeleteCollectionEval, ListRecordsEval]
+};
+  
+export default config;
+  
+export const evals = [GetCollectionsEval, CreateCollectionEval, UpdateCollectionEval, DeleteCollectionEval, ListRecordsEval];

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@datastax/astra-db-ts": "^1.5.0",
     "@modelcontextprotocol/sdk": "^1.6.1",
     "dotenv": "^16.4.7",
-    "jsonschema": "^1.5.0"
+    "jsonschema": "^1.5.0",
+    "mcp-evals": "^1.0.18"
   },
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.4.1",


### PR DESCRIPTION
Adds new e2e test that loads an MCP client, which in turn runs the server and processes the actual tool call. Afterwards, it then grades the response for correctness. 

note: I'm the package author 