### PR TITLE
Update npm ci command to include legacy-peer-deps

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -27,7 +27,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies (including devDependencies)
-        run: npm ci
+        run: npm ci --legacy-peer-deps
         env:
           NODE_ENV: development
 


### PR DESCRIPTION
As the following [PR#33](https://github.com/datastax/astra-db-mcp/pull/33) fixed Dockerfile for building with Docker, I want to add the same fix to the `release-on-main.yml`, which would resolve CI issue for pushing the package to npm.

